### PR TITLE
Set explicit rootDir in tsconfig.eslint.json for TS 6 compat

### DIFF
--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,7 +3,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "./"
   },
   "exclude": ["dist", "node_modules", "script"],
   "include": [


### PR DESCRIPTION
## Summary

- TypeScript 6 now requires an explicit `rootDir` when a tsconfig's `include` spans multiple parent directories (`TS5011`). `tsconfig.eslint.json` includes `src/` plus several top-level JS/TS config files, so the inferred common source directory collapsed per-compilation and TS 6 refused to guess.
- `ts-jest` uses this config (see `jest.config.js:39`), so all 6 test suites fail to run on the TypeScript 6 dependabot branch (#127) with `TS5011: The common source directory of 'tsconfig.eslint.json' is './src/...'. The 'rootDir' setting must be explicitly set`.
- Setting `"rootDir": "./"` matches the actual include set and restores a green test run under TS 6.

Once this lands, dependabot will rebase #127 and its CI should go green.

## Test plan

- [x] Reproduced the failure locally against `pr-127` (TS 6.0.3): 6 suites fail at compile with `TS5011`
- [x] Applied the fix on top of `pr-127`: `npm test` → **6 suites passed, 30 tests passed**
- [ ] CI passes on this PR (under TS 5.9.3 — should be no-op, since `rootDir` was already the effective value)
- [ ] After merge: verify dependabot #127 CI turns green after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)