### PR TITLE
Pass repositoryUrl directly into publish reporter

### DIFF
--- a/src/publish/__tests__/main.test.ts
+++ b/src/publish/__tests__/main.test.ts
@@ -94,6 +94,10 @@ describe('main.ts', () => {
     )
 
     expect(createPublisherReporter).toHaveBeenCalledTimes(1)
+    expect(createPublisherReporter).toHaveBeenNthCalledWith(
+      1,
+      'https://repo.example.com/'
+    )
     expect(client.publishAttestation).toHaveBeenNthCalledWith(
       1,
       'type11',
@@ -162,6 +166,10 @@ describe('main.ts', () => {
     )
 
     expect(createPublisherReporter).toHaveBeenCalledTimes(1)
+    expect(createPublisherReporter).toHaveBeenNthCalledWith(
+      1,
+      'https://repo.example.com/'
+    )
     expect(client.publishAttestation).toHaveBeenNthCalledWith(
       1,
       'type22',

--- a/src/publish/__tests__/reporter.test.ts
+++ b/src/publish/__tests__/reporter.test.ts
@@ -46,7 +46,12 @@ describe('publishing reporter.js', () => {
       }
     }
 
-    new PublisherSummaryReporter().report(404, subject, payload, true)
+    new PublisherSummaryReporter('develocitytia.jfrog.io/docker-trial').report(
+      404,
+      subject,
+      payload,
+      true
+    )
 
     expect(core.setFailed).toHaveBeenCalledWith(
       'Attestation publishing for subject pkg:oci/java-payment-calculator@1.0.0-SNAPSHOT-16152750186-3 errored'
@@ -68,7 +73,12 @@ describe('publishing reporter.js', () => {
       }
     }
 
-    new PublisherSummaryReporter().report(400, subject, payload, true)
+    new PublisherSummaryReporter('develocitytia.jfrog.io/docker-trial').report(
+      400,
+      subject,
+      payload,
+      true
+    )
 
     expect(core.setFailed).toHaveBeenCalledWith(
       'Attestation publishing for subject pkg:oci/java-payment-calculator@1.0.0-SNAPSHOT-16152750186-3 errored'
@@ -90,7 +100,12 @@ describe('publishing reporter.js', () => {
       }
     }
 
-    new PublisherSummaryReporter().report(200, subject, payload, true)
+    new PublisherSummaryReporter('develocitytia.jfrog.io/docker-trial').report(
+      200,
+      subject,
+      payload,
+      true
+    )
 
     expect(core.setFailed).not.toHaveBeenCalled()
     expect(core.error).not.toHaveBeenCalled()
@@ -111,7 +126,7 @@ function renderAndCompare(
     'utf8'
   )
 
-  new PublisherSummaryReporter().report(
+  new PublisherSummaryReporter('develocitytia.jfrog.io/docker-trial').report(
     status,
     { name: subjectName, digest: { sha256: digest } },
     payload,

--- a/src/publish/main.ts
+++ b/src/publish/main.ts
@@ -69,7 +69,7 @@ export async function run(): Promise<void> {
     )
 
     // create summary
-    const reporter = createPublisherReporter()
+    const reporter = createPublisherReporter(repositoryUrl)
     const subject = new PublishRequestSubject(subjectPurl.toString(), {
       sha256: subjectDigest
     })

--- a/src/publish/reporter.ts
+++ b/src/publish/reporter.ts
@@ -11,12 +11,14 @@ import {
   StoreRequest
 } from './model.js'
 
-export function createPublisherReporter(): Reporter<
+export function createPublisherReporter(
+  repositoryUrl: string
+): Reporter<
   PublishRequestSubject,
   PublishSuccessResponse,
   PublishErrorResponse
 > {
-  return new PublisherSummaryReporter()
+  return new PublisherSummaryReporter(repositoryUrl)
 }
 
 export class PublisherSummaryReporter extends BaseReporter<
@@ -24,6 +26,13 @@ export class PublisherSummaryReporter extends BaseReporter<
   PublishSuccessResponse,
   PublishErrorResponse
 > {
+  private readonly repositoryUrl: string
+
+  constructor(repositoryUrl: string) {
+    super()
+    this.repositoryUrl = repositoryUrl
+  }
+
   reportSuccess(
     subject: PublishRequestSubject,
     result: PublishSuccessResponse
@@ -33,16 +42,13 @@ export class PublisherSummaryReporter extends BaseReporter<
     )
 
     header('Attestations Published')
-    subjectInfo(subject, result)
+    subjectInfo(subject, this.repositoryUrl, result)
 
     const items = groupSuccessByResource(result.successes)
     const rows: SummaryTableRow[] = [headerRow()]
 
     items.forEach((success) => {
-      const row = successItemToRow(
-        success,
-        result.request.criteria.repositoryUrl
-      )
+      const row = successItemToRow(success, this.repositoryUrl)
       rows.push(row)
     })
 
@@ -67,7 +73,7 @@ export class PublisherSummaryReporter extends BaseReporter<
 
     // print table if we have errors or successes
     if (result?.errors || result?.successes) {
-      subjectInfo(subject, result)
+      subjectInfo(subject, this.repositoryUrl, result)
 
       // header
       const rows: SummaryTableRow[] = [errorHeaderRow()]
@@ -79,7 +85,7 @@ export class PublisherSummaryReporter extends BaseReporter<
         })
       }
 
-      rows.push(...successRows(result, result.request.criteria.repositoryUrl))
+      rows.push(...successRows(result, this.repositoryUrl))
       core.summary.addTable(rows)
       core.summary.addEOL()
     }
@@ -88,11 +94,12 @@ export class PublisherSummaryReporter extends BaseReporter<
 
 function subjectInfo(
   subject: PublishRequestSubject,
+  repositoryUrl: string,
   result?: PublishSuccessResponse | PublishErrorResponse
 ) {
   let uiArtifactUri
   if (result && result.request) {
-    const repoUrlParts = result.request.criteria.repositoryUrl.split('/')
+    const repoUrlParts = repositoryUrl.split('/')
     const tag = result.request.pkg.version
 
     // get the artifact uri from the result items


### PR DESCRIPTION
The publish reporter was reading repositoryUrl from the server response echo (result.request.criteria.repositoryUrl) and calling .split('/') on it. A server-side response shape change made that value non-string at runtime, breaking the action after a successful publish with:

  result.request.criteria.repositoryUrl.split is not a function

The value is already known locally from the subject-repository-url input, so thread it through createPublisherReporter() and the PublisherSummaryReporter constructor instead of trusting the server echo.